### PR TITLE
応募フロー実装

### DIFF
--- a/backend/app/controllers/applications_controller.rb
+++ b/backend/app/controllers/applications_controller.rb
@@ -4,7 +4,7 @@ class ApplicationsController < ApplicationController
   def create
     application = current_user.applications.build(application_params)
 
-    if review.save
+    if application.save
       render json: {
         message: "Application successfully created",
         application: application
@@ -19,6 +19,6 @@ class ApplicationsController < ApplicationController
   private
 
   def application_params
-    params.require(:review).permit(:recruitment_id)
+    params.require(:application).permit(:recruitment_id)
   end
 end

--- a/backend/app/controllers/applications_controller.rb
+++ b/backend/app/controllers/applications_controller.rb
@@ -6,10 +6,21 @@ class ApplicationsController < ApplicationController
     company = current_company
     applications = company.applications.includes(:user, :recruitment)
 
-    render json: applications.as_json(include: {
-      user: { only: [:id, :name, :email] },
-      recruitment: { only: [:id, :title, :industry] }
-    })
+    render json: applications.map { |application|
+    {
+      application: application,
+      user: {
+        id: application.user.id,
+        name: application.user.last_name + application.user.first_name,
+        email: application.user.email
+      },
+      recruitment: {
+        id: application.recruitment.id,
+        title: application.recruitment.title,
+        industry: application.recruitment.industry
+      }
+    }
+  }
   end
 
   def create

--- a/backend/app/controllers/applications_controller.rb
+++ b/backend/app/controllers/applications_controller.rb
@@ -1,0 +1,24 @@
+class ApplicationsController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    application = current_user.applications.build(application_params)
+
+    if review.save
+      render json: {
+        message: "Application successfully created",
+        application: application
+      }, status: :created
+    else
+      render json: {
+        errors: application.errors.full_messages
+      }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def application_params
+    params.require(:review).permit(:recruitment_id)
+  end
+end

--- a/backend/app/controllers/applications_controller.rb
+++ b/backend/app/controllers/applications_controller.rb
@@ -1,5 +1,16 @@
 class ApplicationsController < ApplicationController
-  before_action :authenticate_user!
+  before_action :authenticate_user!, only: [:create]
+  before_action :authenticate_company!, only: [:index]
+
+  def index
+    company = current_company
+    applications = company.applications.includes(:user, :recruitment)
+
+    render json: applications.as_json(include: {
+      user: { only: [:id, :name, :email] },
+      recruitment: { only: [:id, :title, :industry] }
+    })
+  end
 
   def create
     application = current_user.applications.build(application_params)

--- a/backend/app/controllers/recruitments_controller.rb
+++ b/backend/app/controllers/recruitments_controller.rb
@@ -1,5 +1,6 @@
 class RecruitmentsController < ApplicationController
-  before_action :set_recruitment, only: %i[ show edit update destroy ]
+  before_action :set_recruitment, only: %i[ show edit update destroy]
+  before_action :authenticate_user!, only: %i[ confirm ]
 
   # GET /recruitments
   def index
@@ -32,6 +33,24 @@ class RecruitmentsController < ApplicationController
     else
       render json: { message: "Recruitment not found" }, status: :not_found
     end
+  end
+
+  # GET /recruitments/:id/confirm
+  def confirm
+    @recruitment = Recruitment.includes(:company).find_by(id: params[:id])
+    @user = current_user
+
+    if @recruitment && @user
+      render json: {
+        recruitment: @recruitment,
+        company: @recruitment.company,
+        user: @user,
+        is_applied: @user.applications.exists?(recruitment_id: @recruitment.id)
+      }
+    else
+      render json: { message: "Recruitment not found" }, status: :not_found
+    end
+    
   end
 
 

--- a/backend/app/helpers/applications_helper.rb
+++ b/backend/app/helpers/applications_helper.rb
@@ -1,0 +1,2 @@
+module ApplicationsHelper
+end

--- a/backend/app/models/application.rb
+++ b/backend/app/models/application.rb
@@ -1,0 +1,13 @@
+class Application < ApplicationRecord
+  belongs_to :user
+  belongs_to :recruitment
+
+  enum status: {
+    in_progress: 0,
+    approved: 1,
+    rejected: 2
+  }
+
+  validates :user_id, presence: true
+  validates :recruitment_id, presence: true
+end

--- a/backend/app/models/application.rb
+++ b/backend/app/models/application.rb
@@ -10,4 +10,6 @@ class Application < ApplicationRecord
 
   validates :user_id, presence: true
   validates :recruitment_id, presence: true
+  validates :status, presence: true
+  validates :user_id, uniqueness: { scope: :recruitment_id, message: "この求人にはすでに応募しています。" }
 end

--- a/backend/app/models/company.rb
+++ b/backend/app/models/company.rb
@@ -1,6 +1,7 @@
 class Company < ApplicationRecord
         has_many :recruitments, dependent: :destroy
         has_many :reviews, dependent: :destroy
+        has_many :applications, through: :recruitments
 
         # Include default devise modules.
         devise :database_authenticatable, :registerable,

--- a/backend/app/models/recruitment.rb
+++ b/backend/app/models/recruitment.rb
@@ -1,3 +1,4 @@
 class Recruitment < ApplicationRecord
   belongs_to :company
+  has_many :applications, dependent: :destroy
 end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -13,4 +13,5 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :validatable
   include DeviseTokenAuth::Concerns::User
   has_many :reviews, dependent: :destroy
+  has_many :applications, dependent: :destroy
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
     resources :messages, only: [:create]
   end
 
-  resources :applications, only: [:create]
+  resources :applications, only: [:create, :index]
 
   get 'users', to: 'users#index'
   get '/mypage', to: 'users#mypage'

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -13,6 +13,10 @@ Rails.application.routes.draw do
     collection do
       get 'by_company_id', to: 'recruitments#by_company_id'
     end
+
+    member do
+      get 'confirm', to: 'recruitments#confirm'
+    end
   end
   resources :chat_rooms, only: [:create, :index, :show] do
     resources :messages, only: [:create]

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -17,8 +17,8 @@ Rails.application.routes.draw do
   resources :chat_rooms, only: [:create, :index, :show] do
     resources :messages, only: [:create]
   end
-  resources :companies
-  resources :reviews, only: [:create]
+
+  resources :applications, only: [:create]
 
   get 'users', to: 'users#index'
   get '/mypage', to: 'users#mypage'

--- a/backend/db/migrate/20241123090515_create_applications.rb
+++ b/backend/db/migrate/20241123090515_create_applications.rb
@@ -1,0 +1,10 @@
+class CreateApplications < ActiveRecord::Migration[7.0]
+  def change
+    create_table :applications do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :recruitment, null: false, foreign_key: true
+      t.integer :status, null: false, default: 0
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/migrate/20241123090515_create_applications.rb
+++ b/backend/db/migrate/20241123090515_create_applications.rb
@@ -6,5 +6,8 @@ class CreateApplications < ActiveRecord::Migration[7.0]
       t.integer :status, null: false, default: 0
       t.timestamps
     end
+
+    # 同じ求人に対して同じユーザーが複数回応募できないようにする
+    add_index :applications, [:user_id, :recruitment_id], unique: true
   end
 end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_11_20_070715) do
+ActiveRecord::Schema[7.0].define(version: 2024_11_23_090515) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "applications", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "recruitment_id", null: false
+    t.integer "status", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["recruitment_id"], name: "index_applications_on_recruitment_id"
+    t.index ["user_id"], name: "index_applications_on_user_id"
+  end
 
   create_table "chat_rooms", force: :cascade do |t|
     t.bigint "user_id"
@@ -172,6 +182,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_11_20_070715) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "applications", "recruitments"
+  add_foreign_key "applications", "users"
   add_foreign_key "chat_rooms", "companies"
   add_foreign_key "chat_rooms", "recruitments"
   add_foreign_key "chat_rooms", "users"

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -21,6 +21,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_11_23_090515) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["recruitment_id"], name: "index_applications_on_recruitment_id"
+    t.index ["user_id", "recruitment_id"], name: "index_applications_on_user_id_and_recruitment_id", unique: true
     t.index ["user_id"], name: "index_applications_on_user_id"
   end
 

--- a/backend/test/controllers/applications_controller_test.rb
+++ b/backend/test/controllers/applications_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ApplicationsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/backend/test/fixtures/applications.yml
+++ b/backend/test/fixtures/applications.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/backend/test/models/application_test.rb
+++ b/backend/test/models/application_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ApplicationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/frontend-company/src/app/applications/page.tsx
+++ b/frontend-company/src/app/applications/page.tsx
@@ -1,40 +1,85 @@
 "use client";
-import React, { useEffect, useState } from "react";
-import { User } from "@/types/user";
-import UserCard from "@/components/UserCard";
+import React, { useState, useEffect } from "react";
+import Cookies from "js-cookie";
+import axios from "@/utils/axiosConfig";
 
-export default function Applications() {
-  const [users, setUsers] = useState<User[]>([]);
+interface User {
+  id: number;
+  name: string;
+  email: string;
+}
+
+interface Recruitment {
+  id: number;
+  title: string;
+  industry: string;
+}
+
+interface Application {
+  id: number;
+  status: string;
+  created_at: string;
+}
+
+interface ApplicationWithUser {
+  application: Application;
+  user: User;
+  recruitment: Recruitment;
+}
+
+export default function ApplicationList() {
+  const [applications, setApplications] = useState<ApplicationWithUser[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const fetchUsers = async () => {
+    const fetchApplications = async () => {
       try {
-        const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}users`);
-        if (!response.ok) {
-          throw new Error("Failed to fetch users");
-        }
-        const data = await response.json();
-        setUsers(data);
+        const response = await axios.get(
+          `${process.env.NEXT_PUBLIC_API_URL}applications`,
+          {
+            headers: {
+              "access-token": Cookies.get("access-token"),
+              client: Cookies.get("client"),
+              uid: Cookies.get("uid"),
+            },
+          }
+        );
+
+        setApplications(response.data);
       } catch (error) {
-        setError((error as Error).message);
+        console.error("ページデータの取得に失敗しました:", error);
+        setError("エラーが発生しました");
       } finally {
         setLoading(false);
       }
     };
 
-    fetchUsers();
+    fetchApplications();
   }, []);
 
   if (loading) return <div>Loading...</div>;
   if (error) return <div>Error: {error}</div>;
 
   return (
-    <div>
-      <div className="font-bold text-xl p-12">アクティブユーザー</div>
-      {users.map((user) => (
-        <UserCard key={user.id} user={user} />
+    <div className="max-w-4xl mx-auto p-4 space-y-4">
+      <h1 className="text-2xl font-bold text-center">応募一覧</h1>
+      {applications.map((application) => (
+        <div
+          key={application.application.id}
+          className="p-4 border rounded shadow bg-white"
+        >
+          <h2 className="text-lg font-bold">
+            {application.recruitment.title} ({application.recruitment.industry})
+          </h2>
+          <p className="text-sm text-gray-700">
+            <strong>応募者:</strong> {application.user.name} (
+            {application.user.email})
+          </p>
+          <p className="text-sm text-gray-700">
+            <strong>進行状況:</strong> {application.application.status}
+          </p>
+        </div>
       ))}
     </div>
   );

--- a/frontend-company/src/app/applications/page.tsx
+++ b/frontend-company/src/app/applications/page.tsx
@@ -1,7 +1,41 @@
-import React from 'react'
+"use client";
+import React, { useEffect, useState } from "react";
+import { User } from "@/types/user";
+import UserCard from "@/components/UserCard";
 
 export default function Applications() {
+  const [users, setUsers] = useState<User[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchUsers = async () => {
+      try {
+        const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}users`);
+        if (!response.ok) {
+          throw new Error("Failed to fetch users");
+        }
+        const data = await response.json();
+        setUsers(data);
+      } catch (error) {
+        setError((error as Error).message);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchUsers();
+  }, []);
+
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error}</div>;
+
   return (
-    <div className="font-bold text-xl p-12">応募者一覧</div>
-  )
+    <div>
+      <div className="font-bold text-xl p-12">アクティブユーザー</div>
+      {users.map((user) => (
+        <UserCard key={user.id} user={user} />
+      ))}
+    </div>
+  );
 }

--- a/frontend-company/src/components/SideBar.tsx
+++ b/frontend-company/src/components/SideBar.tsx
@@ -8,27 +8,42 @@ const Sidebar: React.FC = () => {
       <nav className="mt-4">
         <ul>
           <li>
-            <Link href="/recruitments" className="block w-full h-full p-6 hover:bg-purple-500">
+            <Link
+              href="/recruitments"
+              className="block w-full h-full p-6 hover:bg-purple-500"
+            >
               作成した求人
             </Link>
           </li>
           <li>
-            <Link href="/create" className="block w-full h-full p-6 hover:bg-purple-500">
+            <Link
+              href="/create"
+              className="block w-full h-full p-6 hover:bg-purple-500"
+            >
               求人を作成する
             </Link>
           </li>
           <li>
-            <Link href="/students" className="block w-full h-full p-6 hover:bg-purple-500">
+            <Link
+              href="/students"
+              className="block w-full h-full p-6 hover:bg-purple-500"
+            >
               つくばの学生一覧
             </Link>
           </li>
           <li>
-            <Link href="/applications" className="block w-full h-full p-6 hover:bg-purple-500">
-              応募者一覧
+            <Link
+              href="/applications"
+              className="block w-full h-full p-6 hover:bg-purple-500"
+            >
+              応募一覧
             </Link>
           </li>
           <li>
-            <Link href="/chats" className="block w-full h-full p-6 hover:bg-purple-500">
+            <Link
+              href="/chats"
+              className="block w-full h-full p-6 hover:bg-purple-500"
+            >
               チャット一覧
             </Link>
           </li>

--- a/frontend-company/src/types/application.ts
+++ b/frontend-company/src/types/application.ts
@@ -1,0 +1,8 @@
+export interface Application {
+  id: number;
+  recruitment_id: number;
+  user_id: number;
+  status: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend-user/src/app/recruitments/[id]/confirm/page.tsx
+++ b/frontend-user/src/app/recruitments/[id]/confirm/page.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import axios from "@/utils/axiosConfig";
+import { Recruitment } from "@/types/recruitment";
+import { Company } from "@/types/company";
+import { User } from "@/types/user"; // 必要なら型を定義
+import Cookies from "js-cookie";
+
+interface RecruitmentWithCompany {
+  recruitment: Recruitment;
+  company: Company;
+}
+
+const ApplicationConfirmationPage = () => {
+  const { id } = useParams(); // 求人ID
+  const router = useRouter();
+  const [data, setData] = useState<RecruitmentWithCompany | null>(null);
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    const fetchRecruitmentData = async () => {
+      try {
+        if (id) {
+          const response = await axios.get(
+            `${process.env.NEXT_PUBLIC_API_URL}recruitments/${id}`
+          );
+          setData(response.data); // APIから取得したデータをstateにセット
+        }
+      } catch (error) {
+        console.error("企業情報の取得に失敗しました:", error);
+      }
+    };
+
+    const fetchUserData = async () => {
+      try {
+        const response = await axios.get(
+          `${process.env.NEXT_PUBLIC_API_URL}mypage`,
+          {
+            headers: {
+              "access-token": Cookies.get("access-token"),
+              client: Cookies.get("client"),
+              uid: Cookies.get("uid"),
+            },
+          }
+        );
+        setUser(response.data); // APIから取得したデータをstateにセット
+      } catch (error) {
+        console.error("ユーザ情報の取得に失敗しました:", error);
+      }
+    };
+
+    fetchUserData();
+    fetchRecruitmentData();
+  }, [id]);
+
+  if (!data || !user) {
+    return <p>Loading...</p>;
+  }
+
+  const { recruitment, company } = data;
+
+  const handleConfirm = async () => {
+    try {
+      await axios.post(`/applications`, {
+        recruitment_id: recruitment.id,
+      });
+      alert("応募が完了しました！");
+      router.push("/applications"); // 適切なページに遷移
+    } catch (error) {
+      console.error("応募に失敗しました:", error);
+      alert("応募に失敗しました。再度お試しください。");
+    }
+  };
+
+  const handleBack = () => {
+    router.back(); // 前のページに戻る
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto p-6 mt-6 space-y-6 bg-white shadow rounded-lg">
+      <h1 className="text-2xl font-bold text-center">応募内容確認</h1>
+
+      {/* 求人情報 */}
+      <div className="p-4 bg-blue-50 border rounded">
+        <h2 className="text-lg font-bold">{recruitment.title}</h2>
+        <p className="text-sm text-gray-500">{company.name}</p>
+        <div className="mt-2 flex gap-2">
+          <span className="px-2 py-1 bg-gray-200 text-sm rounded">
+            業界: {recruitment.industry}
+          </span>
+          <span className="px-2 py-1 bg-gray-200 text-sm rounded">
+            職種: {recruitment.job_titles}
+          </span>
+        </div>
+      </div>
+
+      {/* 確認メッセージ */}
+      <p className="text-sm text-gray-500 text-center">
+        登録情報に間違いがないか、必ずご確認ください。
+      </p>
+
+      {/* プロフィール情報 */}
+      <div className="p-4 bg-gray-50 border rounded space-y-2">
+        <p>
+          <strong>ID (メールアドレス):</strong> {user.email}
+        </p>
+        <p>
+          <strong>姓:</strong> {user.last_name}
+        </p>
+        <p>
+          <strong>名:</strong> {user.first_name}
+        </p>
+        <p>
+          <strong>学校名:</strong> {user.university}
+        </p>
+        <p>
+          <strong>卒業予定年:</strong> {user.graduation_year} 年
+        </p>
+        <p>
+          <strong>卒業予定月:</strong> {user.graduation_month} 月
+        </p>
+      </div>
+
+      {/* プロフィール編集リンク */}
+      <div className="text-sm text-gray-700 bg-gray-100 border rounded p-4">
+        <p>プロフィールが充実していると採用率が高くなります。</p>
+        {/* TODO: リンク先を修正 */}
+        <Link
+          href="/hoge"
+          className="text-blue-500 underline hover:text-blue-700"
+        >
+          プロフィールを編集する
+        </Link>
+      </div>
+
+      {/* 自己PR */}
+      <div className="p-4 bg-yellow-50 border rounded space-y-2">
+        <h3 className="text-lg font-bold">自己PR</h3>
+        <p>{user.achievement || "アピール内容は登録されていません。"}</p>
+      </div>
+
+      {/* ボタン */}
+      <div className="flex justify-between">
+        <button
+          onClick={handleBack}
+          className="bg-gray-300 text-black px-4 py-2 rounded hover:bg-gray-400"
+        >
+          戻る
+        </button>
+        <button
+          onClick={handleConfirm}
+          className="bg-main-col text-white px-4 py-2 rounded hover:bg-purple-700"
+        >
+          応募する
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ApplicationConfirmationPage;

--- a/frontend-user/src/app/recruitments/[id]/confirm/page.tsx
+++ b/frontend-user/src/app/recruitments/[id]/confirm/page.tsx
@@ -19,44 +19,37 @@ const ApplicationConfirmationPage = () => {
   const router = useRouter();
   const [data, setData] = useState<RecruitmentWithCompany | null>(null);
   const [user, setUser] = useState<User | null>(null);
+  const [isApplied, setIsApplied] = useState(false); // 応募済みかどうか
   const [isSubmitting, setIsSubmitting] = useState(false); // ローディング状態
 
   useEffect(() => {
-    const fetchRecruitmentData = async () => {
+    const fetchPageData = async () => {
       try {
         if (id) {
           const response = await axios.get(
-            `${process.env.NEXT_PUBLIC_API_URL}recruitments/${id}`
+            `${process.env.NEXT_PUBLIC_API_URL}recruitments/${id}/confirm`,
+            {
+              headers: {
+                "access-token": Cookies.get("access-token"),
+                client: Cookies.get("client"),
+                uid: Cookies.get("uid"),
+              },
+            }
           );
-          setData(response.data); // APIから取得したデータをstateにセット
+          const { recruitment, company, user, is_applied } = response.data;
+
+          setData({ recruitment, company });
+          setUser(user);
+          setIsApplied(is_applied);
         }
       } catch (error) {
-        console.error("企業情報の取得に失敗しました:", error);
-      }
-    };
-
-    const fetchUserData = async () => {
-      try {
-        const response = await axios.get(
-          `${process.env.NEXT_PUBLIC_API_URL}mypage`,
-          {
-            headers: {
-              "access-token": Cookies.get("access-token"),
-              client: Cookies.get("client"),
-              uid: Cookies.get("uid"),
-            },
-          }
-        );
-        setUser(response.data); // APIから取得したデータをstateにセット
-      } catch (error) {
-        console.error("ユーザ情報の取得に失敗しました:", error);
+        console.error("ページデータの取得に失敗しました:", error);
       } finally {
         setIsSubmitting(false); // ローディング状態を解除
       }
     };
 
-    fetchUserData();
-    fetchRecruitmentData();
+    fetchPageData();
   }, [id]);
 
   if (!data || !user) {
@@ -113,7 +106,6 @@ const ApplicationConfirmationPage = () => {
   return (
     <div className="max-w-2xl mx-auto p-6 mt-6 space-y-6 bg-white shadow rounded-lg">
       <h1 className="text-2xl font-bold text-center">応募内容確認</h1>
-
       {/* 求人情報 */}
       <div className="p-4 bg-blue-50 border rounded">
         <h2 className="text-lg font-bold">{recruitment.title}</h2>
@@ -127,12 +119,10 @@ const ApplicationConfirmationPage = () => {
           </span>
         </div>
       </div>
-
       {/* 確認メッセージ */}
       <p className="text-sm text-gray-500 text-center">
         登録情報に間違いがないか、必ずご確認ください。
       </p>
-
       {/* プロフィール情報 */}
       <div className="p-4 bg-gray-50 border rounded space-y-2">
         <p>
@@ -154,7 +144,6 @@ const ApplicationConfirmationPage = () => {
           <strong>卒業予定月:</strong> {user.graduation_month} 月
         </p>
       </div>
-
       {/* プロフィール編集リンク */}
       <div className="text-sm text-gray-700 bg-gray-100 border rounded p-4">
         <p>プロフィールが充実していると採用率が高くなります。</p>
@@ -166,13 +155,11 @@ const ApplicationConfirmationPage = () => {
           プロフィールを編集する
         </Link>
       </div>
-
       {/* 自己PR */}
       <div className="p-4 bg-yellow-50 border rounded space-y-2">
         <h3 className="text-lg font-bold">自己PR</h3>
         <p>{user.achievement || "アピール内容は登録されていません。"}</p>
       </div>
-
       {/* ボタン */}
       <div className="flex justify-between">
         <button
@@ -181,17 +168,26 @@ const ApplicationConfirmationPage = () => {
         >
           戻る
         </button>
-        <button
-          onClick={handleConfirm}
-          className={`bg-main-col text-white px-4 py-2 rounded ${
-            isSubmitting
-              ? "opacity-50 cursor-not-allowed"
-              : "hover:bg-purple-700"
-          }`}
-          disabled={isSubmitting}
-        >
-          {isSubmitting ? "処理中..." : "応募する"}
-        </button>
+        {isApplied ? (
+          <button
+            className="bg-gray-300 text-black px-4 py-2 rounded cursor-not-allowed"
+            disabled
+          >
+            応募済み
+          </button>
+        ) : (
+          <button
+            onClick={handleConfirm}
+            className={`bg-main-col text-white px-4 py-2 rounded ${
+              isSubmitting
+                ? "opacity-50 cursor-not-allowed"
+                : "hover:bg-purple-700"
+            }`}
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? "処理中..." : "応募する"}
+          </button>
+        )}
       </div>
     </div>
   );

--- a/frontend-user/src/app/recruitments/[id]/page.tsx
+++ b/frontend-user/src/app/recruitments/[id]/page.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from "react";
 import { useRouter, useParams } from "next/navigation";
 import Image from "next/image";
 import Link from "next/link";
-import axios from "@/utils/axiosConfig";
 import { Recruitment } from "../../../types/recruitment";
 import { Company } from "../../../types/company";
 import { doesCookieExist } from "@/utils/cookieUtils";
@@ -35,20 +34,12 @@ const RecruitmentDetailPage = () => {
   const image_num = (recruitment.id % 7) + 1; // Adjusted for image logic
 
   const applyForJob = async () => {
-    if (!doesCookieExist('uid')) {
-      router.push('/sign_in');
+    if (!doesCookieExist("uid")) {
+      router.push("/sign_in");
       return;
     }
 
-    try {
-      const response = await axios.post(`chat_rooms/`, {
-        company_id: company?.id,
-        recruitment_id: recruitment?.id,
-      });
-      router.push(`/chat_rooms/${response.data.id}`);
-    } catch (error) {
-      console.error("応募に失敗しました", error);
-    }
+    router.push(`/recruitments/${recruitment.id}/confirm`);
   };
 
   return (


### PR DESCRIPTION
https://tsukukatsu.atlassian.net/browse/TSUKU-107

## 概要
応募した際のフローの調整

## 修正内容
### before
応募する -> チャット画面に遷移

### after
応募する -> 確認画面に遷移 -> チャット画面に遷移（同時に応募インスタンスも作成）

## 影響範囲
backend
frontend-user
frontend-company

## 補足
### まだできていないこと
- 応募した際のメール送信
- ユーザー情報編集ページへのリンク（りくができたら直す）

### 確認画面
<img width="711" alt="スクリーンショット 2024-11-23 21 10 42" src="https://github.com/user-attachments/assets/c8a69d1d-72e0-4efd-80b2-460676682572">

### 確認画面（応募済み求人の場合）
<img width="715" alt="スクリーンショット 2024-11-24 17 55 44" src="https://github.com/user-attachments/assets/93914bfe-ed21-4dbd-8f67-cbc53e559dca">

### 企業側応募一覧画面（UIは適当、応募が取得できていることがわかる）
![スクリーンショット 2024-11-24 20 45 39](https://github.com/user-attachments/assets/abd90c10-e239-4d2c-aded-7c9e0c7eb4bf)



